### PR TITLE
bugfix: close global binding type schemes under the ForAll correctly

### DIFF
--- a/src/Compiler/TypeChecker/Inference/TypeOf.hs
+++ b/src/Compiler/TypeChecker/Inference/TypeOf.hs
@@ -76,7 +76,10 @@ infer'expression env expr = case runInfer env (infer expr) of
 infer'many :: [(String, Expression)] -> Infer ([(String, Type)], [Constraint])
 infer'many bindings = do
   let names = map fst bindings
-      gener name = do ForAll [] <$> fresh
+      gener name = do
+        var <- fresh
+        let (TyVar var'name) = var
+        return $ ForAll [var'name] (TyVar var'name)
   fresh'vars <- mapM gener names
   merge'into'env (zip names fresh'vars) $ infer'many' bindings
   


### PR DESCRIPTION
Before the fix - because the `ForAll` scheme didn't correctly close the `fresh and free type variable` it caused the whole inference act like each identifier should have exactly one type - `monomoprhic type` at some instances.

For example having snippet like this:
```haskell
foo a b = if True then a else b -- this should be of type forall a . a -> a -> a

-- then using it
bar = (foo 23 42) -- this causes the foo to monorphize to :: Int -> Int -> Int

baz = (foo 'c' 'a') -- this doesn't type check
```

Now it should always correctly infer the most general, polymorphic type wherever it should. 